### PR TITLE
Index recalculation for update function

### DIFF
--- a/js/jquery.windy.js
+++ b/js/jquery.windy.js
@@ -270,8 +270,22 @@
 	  	// public method: dynamically updates elements list (used in AJAX)
 	        update : function () {
 
-	            this.$items = $( this.$elname ).children( 'li' );
-	            this.itemsCount = this.$items.length;
+			var $old_current_el = this.$items.eq( this.current );
+
+			this.$items = $( this.$elname ).children( 'li' );
+			this.itemsCount = this.$items.length;
+
+			// if new element was prepended into <ul> we have to recalculate current index
+			for( var i = 0; i < this.$items.length; i++ ) {
+
+			    if( this.$items[i] == $old_current_el[0] ) {
+
+				this.current = i;
+				break;
+
+			    }
+
+			}
 
 	        }
 


### PR DESCRIPTION
If we are prepending element into Windy's `<ul>` before currently selected element we have to recalculate indexes. So update function works fine now if we are appending element (adding next), but  due to index = 0 we cannot move to newly prepended element (real index 0).

BTW, test example for documentation:

``` javascript
    $('#wi-el').prepend($li_el.join('\n'));
     windy.update();
     windy.prev();
```

This code works fine in my project (at least in current development process) for ecommerce items pages, thank you for such wounderful product :)
